### PR TITLE
AllValuesFilter over only the provided queryset, not over the whole Model.queryset

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -187,7 +187,7 @@ class DateRangeFilter(ChoiceFilter):
 class AllValuesFilter(ChoiceFilter):
     @property
     def field(self):
-        qs = self.model._default_manager.distinct()
+        qs = getattr(self, 'queryset', self.model._default_manager).distinct()
         qs = qs.order_by(self.name).values_list(self.name, flat=True)
         self.extra['choices'] = [(o, o) for o in qs]
         return super(AllValuesFilter, self).field

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -240,9 +240,10 @@ class BaseFilterSet(object):
             self.strict = strict
 
         self.filters = deepcopy(self.base_filters)
-        # propagate the model being used through the filters
+        # propagate the model and queryset being used through the filters
         for filter_ in self.filters.values():
             filter_.model = self._meta.model
+            filter_.queryset = self.queryset
 
     def __iter__(self):
         for obj in self.qs:


### PR DESCRIPTION
This changes AllValuesFilter to show only values for the queyset provided to the FilterSet. To do this, the FilterSet propagates their .queryset too, in addition to the .model already propagated.