### PR TITLE
Add QuerySetFilter

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -204,15 +204,10 @@ class QuerySetFilter(ChoiceFilter):
         """
         Apply queryset methods
         """
-        method = self.options[value][1]['method']
-        if 'args' in self.options[value][1]:
-            args = self.options[value][1]['args']
-        else:
-            args = ()
-        if 'kwargs' in self.options[value][1]:
-            kwargs = self.options[value][1]['kwargs']
-        else:
-            kwargs = {}
+        config = self.options[value][1]
+        method = config.get('method', '')
+        args = config.get('args', ())
+        kwargs = config.get('kwargs', {})
         if method == '':
             return qs
         elif not hasattr(qs, method):

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -18,7 +18,7 @@ __all__ = [
     'Filter', 'CharFilter', 'BooleanFilter', 'ChoiceFilter',
     'MultipleChoiceFilter', 'DateFilter', 'DateTimeFilter', 'TimeFilter',
     'ModelChoiceFilter', 'ModelMultipleChoiceFilter', 'NumberFilter',
-    'RangeFilter', 'DateRangeFilter', 'AllValuesFilter',
+    'RangeFilter', 'DateRangeFilter', 'AllValuesFilter', 'QuerySetFilter',
 ]
 
 
@@ -191,3 +191,30 @@ class AllValuesFilter(ChoiceFilter):
         qs = qs.order_by(self.name).values_list(self.name, flat=True)
         self.extra['choices'] = [(o, o) for o in qs]
         return super(AllValuesFilter, self).field
+
+
+class QuerySetFilter(ChoiceFilter):
+    def __init__(self, options, *args, **kwargs):
+        self.options = options
+        kwargs['choices'] = [
+            (key, value[0]) for key, value in six.iteritems(self.options)]
+        super(QuerySetFilter, self).__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        """
+        Apply queryset methods
+        """
+        method = self.options[value][1]['method']
+        if 'args' in self.options[value][1]:
+            args = self.options[value][1]['args']
+        else:
+            args = ()
+        if 'kwargs' in self.options[value][1]:
+            kwargs = self.options[value][1]['kwargs']
+        else:
+            kwargs = {}
+        if method == '':
+            return qs
+        elif not hasattr(qs, method):
+            raise Exception("Improperly configured", "Unknown QuerySet method %s" % method)
+        return getattr(qs, method)(*args, **kwargs)


### PR DESCRIPTION
I was wondering if you're interested in something like this QuerySetFilter. It allows easy access to methods of custom QuerySets. It might be interesting due to the QuerySet/Manager updates in 1.7, and I think it can lead to less and better organized code. If yes I'd look into adding tests and a little documentation.

Usage is basically
```
    qs_choices = {
        '': ('---------', {
            'method': '',
        }),   
        'foo': ('Foo', {
            'method': 'foo',
        }),   
        'bar': ('Bar', {
            'method': 'bar',
            'args': (True, 5, 'baz'),
        }),   
    }
    qs_filter = QuerySetFilter(qs_choices, label='QuerySet choices')
```