### PR TITLE
Group filter fields with meta option 'together'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Tom Christie
 Remco Wendt
 Axel Haustant
 Brad Erickson
+Diogo Laginha

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -199,6 +199,24 @@ The inner ``Meta`` class also takes an optional ``form`` argument.  This is a
 form class from which ``FilterSet.form`` will subclass.  This works similar to
 the ``form`` option on a ``ModelAdmin.``
 
+Group fields with ``together``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The inner ``Meta`` class also takes an optional ``together`` argument.  This 
+is a list of lists, each containing field names. For convenience can be a 
+single list/tuple when dealing with a single set of fields. Fields within a 
+field set must either be all or none present in the request for 
+``FilterSet.form`` to be valid.
+
+    import django_filters
+
+    class ProductFilter(django_filters.FilterSet):
+        class Meta:
+            model = Product
+            fields = ['price', 'release_date', 'rating']
+            together = ['rating', 'price']
+
+
 Non-Meta options
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name='django-filter',
-    version='0.9.2',
+    version='0.9.3',
     description=('Django-filter is a reusable Django application for allowing'
                  ' users to filter querysets dynamically.'),
     long_description=readme,


### PR DESCRIPTION
Added a new optional argument for the ``Meta`` class.  This is a list of lists, each containing field names. For convenience it can be a single list/tuple when dealing with a single set of fields. Fields within a field set must either be all or none present in the request for ``FilterSet.form`` to be valid.

```python
import django_filters

class BookFilter(django_filters.FilterSet):
    class Meta:
        model = Stop
        fields = ['name', 'year', 'author', 'publisher']
        together = ['publisher', 'year']
```

I added tests, documentation and updated the version number. 
I hope you like it and that everything is OK according to your standards.
