### PR TITLE
Allow value and human readable option

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -62,11 +62,20 @@ class Filter(object):
                 help_text = _('This is an exclusion filter') if self.exclude else _('Filter')
             if (self.lookup_type is None or
                     isinstance(self.lookup_type, (list, tuple))):
-                if self.lookup_type is None:
-                    lookup = [(x, x) for x in LOOKUP_TYPES]
-                else:
-                    lookup = [
-                        (x, x) for x in LOOKUP_TYPES if x in self.lookup_type]
+
+                lookup = []
+
+                for x in LOOKUP_TYPES:
+                    if isinstance(x, (list, tuple)) and len(x) == 2:
+                        choice = (x[0], x[1])
+                    else:
+                        choice = (x, x)
+
+                    if self.lookup_type is None:
+                        lookup.append(choice)
+                    elif x in self.lookup_type:
+                        lookup.append(choice)
+
                 self._field = LookupTypeField(self.field_class(
                     required=self.required, widget=self.widget, **self.extra),
                     lookup, required=self.required, label=self.label, help_text=help_text)

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -268,10 +268,10 @@ the ``form`` option on a ``ModelAdmin.``
 Group fields with ``together``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The inner ``Meta`` class also takes an optional ``together`` argument.  This 
-is a list of lists, each containing field names. For convenience can be a 
-single list/tuple when dealing with a single set of fields. Fields within a 
-field set must either be all or none present in the request for 
+The inner ``Meta`` class also takes an optional ``together`` argument.  This
+is a list of lists, each containing field names. For convenience can be a
+single list/tuple when dealing with a single set of fields. Fields within a
+field set must either be all or none present in the request for
 ``FilterSet.form`` to be valid::
 
     import django_filters
@@ -365,3 +365,33 @@ to it as the class based view::
 
 The needed template and its context variables will also be the same as the
 class-based view above.
+
+Custom lookup types
+-------------------
+
+By default django-filter uses Django's ORM built-in field lookups. If you want to globally accept specific lookups you can do the following:
+
+    from django_filters import filters
+
+    filters.LOOKUP_TYPES = ['gt', 'gte', 'lt', 'lte', 'custom_lookup_type']
+
+Choices help text
+-----------------
+
+If you want the ``ChoiceField`` created from `LOOKUP_TYPES` to have human-friendly options you can do the following:
+
+    from django_filters import filters
+
+    filters.LOOKUP_TYPES = [
+        ('', '---------'),
+        ('exact', 'Is equal to'),
+        ('not_exact', 'Is not equal to'),
+        ('lt', 'Lesser than'),
+        ('gt', 'Greater than'),
+        ('gte', 'Greater than or equal to'),
+        ('lte', 'Lesser than or equal to'),
+        ('startswith', 'Starts with'),
+        ('endswith', 'Ends with'),
+        ('contains', 'Contains'),
+        ('not_contains', 'Does not contain'),
+    ]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -15,7 +15,7 @@ from datetime import timedelta
 from django import forms
 from django.test import TestCase
 
-
+from django_filters import filters
 from django_filters.fields import (
     Lookup,
     RangeField,
@@ -766,3 +766,30 @@ class AllValuesFilterTests(TestCase):
         f.model = mocked
         field = f.field
         self.assertIsInstance(field, forms.ChoiceField)
+
+
+class LookupTypesTests(TestCase):
+    def test_custom_lookup_types(self):
+        filters.LOOKUP_TYPES = [
+            ('', '---------'),
+            ('exact', 'Is equal to'),
+            ('not_exact', 'Is not equal to'),
+            ('lt', 'Lesser than'),
+            ('gt', 'Greater than'),
+            ('gte', 'Greater than or equal to'),
+            ('lte', 'Lesser than or equal to'),
+            ('startswith', 'Starts with'),
+            ('endswith', 'Ends with'),
+            ('contains', 'Contains'),
+            ('not_contains', 'Does not contain'),
+        ]
+
+        f = Filter(lookup_type=None)
+        field = f.field
+        choice_field = field.fields[1]
+        choices = choice_field.choices
+
+        self.assertIsInstance(field, LookupTypeField)
+        self.assertEqual(choices, filters.LOOKUP_TYPES)
+        self.assertEqual(choices[1][0], 'exact')
+        self.assertEqual(choices[1][1], 'Is equal to')


### PR DESCRIPTION
LOOKUP_TYPES can in fact be overwritten in scenarios where user wants human readable labels for options when using the [lookup_type](https://django-filter.readthedocs.org/en/latest/ref/filters.html#lookup-type) argument.

```python
from django_filters import filters


filters.LOOKUP_TYPES = [
    ('', '---------'),
    ('exact', 'Is equal to'),
    ('not_exact', 'Is not equal to'),
    ('lt', 'Lesser than'),
    ('gt', 'Greater than'),
    ('gte', 'Greater than or equal to'),
    ('lte', 'Lesser than or equal to'),
    ('startswith', 'Starts with'),
    ('endswith', 'Ends with'),
    ('contains', 'Contains'),
    ('not_contains', 'Does not contain'),
]
```

This doesn't affect any actual filtering behavior, just for choices in `LookupTypeField`.