### PR TITLE
Added default filter method lookup for MethodFilter

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -278,7 +278,7 @@ class MethodFilter(Filter):
         parent = getattr(self, 'parent', None)
         parent_filter_method = getattr(parent, self.parent_action, None)
         if not parent_filter_method:
-            func_str = 'filter_{}'.format(self.name)
+            func_str = 'filter_{0}'.format(self.name)
             parent_filter_method = getattr(parent, func_str, None)
         if parent_filter_method is not None:
             return parent_filter_method(qs, value)

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -268,12 +268,18 @@ class MethodFilter(Filter):
 
     def filter(self, qs, value):
         """
-        This filter method will act as a proxy for the actual method we want to call.
-        It will try to find the method on the parent filterset, if not it defaults
-        to just returning the queryset
+        This filter method will act as a proxy for the actual method we want to
+        call.
+
+        It will try to find the method on the parent filterset,
+        if not it attempts to search for the method `field_{{attribute_name}}`.
+        Otherwise it defaults to just returning the queryset.
         """
         parent = getattr(self, 'parent', None)
         parent_filter_method = getattr(parent, self.parent_action, None)
+        if not parent_filter_method:
+            func_str = 'filter_{}'.format(self.name)
+            parent_filter_method = getattr(parent, func_str, None)
         if parent_filter_method is not None:
             return parent_filter_method(qs, value)
         return qs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -151,3 +151,5 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+livehtml:
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -115,6 +115,72 @@ default filters for all the models fields of the same kind using
             fields = ['name']
 
 
+MethodFilter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you want fine control over each individual filter attribute, you can use
+the ``MethodFilter`` filter.
+
+By passing in the name of a custom defined filter function as an ``action``,
+the filter attribute gets linked to the custom filter function.
+Here is an example of overriding the filter function of the
+filter attribute ``username``
+::
+
+    class F(django_filters.FilterSet):
+            username = MethodFilter(action='my_custom_filter')
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+            def my_custom_filter(self, queryset, value):
+                return queryset.filter(
+                    username=value
+                )
+
+
+The filter function can also be defined outside of the filter class scope.
+Though you would need to pass in the actual function value, not it's name.
+::
+
+        def my_custom_filter(queryset, value):
+            return queryset.filter(
+                username=value
+            )
+
+        class F(django_filters.FilterSet):
+	    # Notice: In this case, action accepts a func, not a string
+            username = MethodFilter(action=filter_username)
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+
+Lastly, when using a ``MethodFilter``, there is no need to define an action.
+You may simply do the following and ``filter_username`` will be auto-detected
+and used. ::
+
+        class F(FilterSet):
+            username = MethodFilter()
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+            def filter_username(self, queryset, value):
+                return queryset.filter(
+                    username__contains='ke'
+                )
+
+Under the hood, if ``action`` not is defined, ``django_filter``
+searches for a class method with a name that follows the pattern
+``filter_{{ATTRIBUTE_NAME}}``. For example, if the attribute name is
+``email``, then the filter class will be scanned for the filter function
+``filter_email``. If no action is provided, and no filter class
+function is found, then the filter attribute will be left unfiltered.
+
+
 The view
 --------
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ Django
 django-discover-runner
 mock
 coverage
+sphinx-autobuild

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -696,6 +696,57 @@ class MethodFilterTests(TestCase):
                          list())
 
 
+    def test_filtering_default_attribute_action(self):
+        User.objects.create(username='mike')
+        User.objects.create(username='jake')
+        User.objects.create(username='aaron')
+
+        class F(FilterSet):
+            username = MethodFilter()
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+            def filter_username(self, queryset, value):
+                return queryset.filter(
+                    username__contains='ke'
+                )
+
+        self.assertEqual(list(F().qs), list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'mike'})),
+                         [User.objects.get(username='mike'),
+                          User.objects.get(username='jake')],)
+        self.assertEqual(list(F({'username': 'jake'})),
+                         [User.objects.get(username='mike'),
+                          User.objects.get(username='jake')])
+        self.assertEqual(list(F({'username': 'aaron'})),
+                         [User.objects.get(username='mike'),
+                          User.objects.get(username='jake')])
+
+
+    def test_filtering_default(self):
+        User.objects.create(username='mike')
+        User.objects.create(username='jake')
+        User.objects.create(username='aaron')
+
+        class F(FilterSet):
+            username = MethodFilter()
+            email = MethodFilter()
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+        self.assertEqual(list(F().qs), list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'mike'})),
+                         list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'jake'})),
+                         list(User.objects.all()))
+        self.assertEqual(list(F({'username': 'aaron'})),
+                         list(User.objects.all()))
+
+
 class O2ORelationshipTests(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Really liked the ability to define and use custom filters via `MethodFilter`. Though passing in the name of the custom filter as an `action` is an extra step that I figured can be removed. 

Here is what this PR proposes.

```python
 class F(FilterSet):
            # Notice, no action parameter is defined
            email = MethodFilter()

            class Meta:
                model = User
                fields = ['email']

            # If no action filter is defined, defaults to filter_{{attribute_name}}
            def filter_email(self, queryset, value):
                return queryset.filter(
                    email__contains='gmail.com'
                )
```
