### PR TITLE
fix get_model_field when using django 1.8

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -80,8 +80,12 @@ def get_model_field(model, f):
         except FieldDoesNotExist:
             return None
         if isinstance(rel, ForeignObjectRel):
-            model = rel.model
-            opts = rel.opts
+            if hasattr(rel, "related_model"):
+                # django >= 1.8 (ForeignObjectRel)
+                opts = rel.related_model._meta
+            else:
+                # django < 1.8 (RelatedObject)
+                opts = rel.opts
         else:
             model = rel.rel.to
             opts = model._meta

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -33,6 +33,7 @@ from .models import BankAccount
 from .models import Node
 from .models import DirectedNode
 from .models import Worker
+from .models import HiredWorker
 from .models import Business
 
 
@@ -48,9 +49,13 @@ class HelperMethodsTests(TestCase):
     def test_get_declared_filters(self):
         pass
 
-    def test_get_model_field(self):
+    def test_get_model_field_none(self):
         result = get_model_field(User, 'unknown__name')
         self.assertIsNone(result)
+
+    def test_get_model_field(self):
+        result = get_model_field(Business, 'hiredworker__worker')
+        self.assertEqual(result, HiredWorker._meta.get_field('worker'))
 
     @unittest.skip('todo')
     def test_filters_for_model(self):


### PR DESCRIPTION
In Django 1.8 ForeignObjectRel objects have no opts attribute.
Instead we should use rel.related_model._meta.
See
 * https://github.com/django/django/blob/1.8/django/db/models/fields/related.py#L1266
 * https://github.com/django/django/blob/1.7.7/django/db/models/related.py#L14