### PR TITLE
for the sake of django 1.8

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -80,8 +80,8 @@ def get_model_field(model, f):
         except FieldDoesNotExist:
             return None
         if isinstance(rel, ForeignObjectRel):
-            model = rel.model
-            opts = rel.opts
+            model = rel.field.model
+            opts = model._meta 
         else:
             model = rel.rel.to
             opts = model._meta


### PR DESCRIPTION
It still does not work in django1.8 and tests prove it

    Traceback (most recent call last):                                          
      File "/home/qwer/projects/django-filter/tests/test_filtering.py", line 904, in test_reverse_fk_relation_attribute
        class F(FilterSet):                                                     
      File "/home/qwer/projects/django-filter/django_filters/filterset.py", line 193, in __new__
        new_class.filter_for_reverse_field)                                     
      File "/home/qwer/projects/django-filter/django_filters/filterset.py", line 107, in filters_for_model
        field = get_model_field(model, f)                                       
      File "/home/qwer/projects/django-filter/django_filters/filterset.py", line 84, in get_model_field
        opts = rel.opts                                                         
    AttributeError: 'ManyToOneRel' object has no attribute 'opts'

The reason is completely opposite behavior of rel.model 1.8 comparing to 1.7
Seems like it the simplest way to fix it
Or we could take attribute based on current django version

    if v >= 1.8:
        res = rel.related_model
    else:
        res = rel.model

Hope it will be fixed in master soon enough too

Oohps, seems like there is already exists pending fix for it. But anyway, as an alternative 