### PR TITLE
Consistency between filtering and ordering names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,23 @@
+Version 0.12.0 (2015-??-??)
+---------------------------
+
+* BREAKING CHANGE: the custom filter names are now also be used for ordering #230
+
+    If you use ordering on a field you defined as custom filter with custom
+    name, you should now use the filter name as ordering key as well.
+
+    Eg. For a filter like :
+
+        class F(FilterSet):
+            account = CharFilter(name='username')
+            class Meta:
+                model = User
+                fields = ['account', 'status']
+                order_by = True
+
+     Before, ordering was like `?o=username`. Since 0.12.0 it's `o=account`.
+
+
 Version 0.11.0 (2015-08-14)
 ---------------------------
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -558,19 +558,29 @@ class FilterSetOrderingTests(TestCase):
         self.assertQuerysetEqual(
             f.qs, ['carl', 'alex', 'jacob', 'aaron'], lambda o: o.username)
 
-    @unittest.skip('todo')
     def test_ordering_uses_filter_name(self):
         class F(FilterSet):
             account = CharFilter(name='username')
-
             class Meta:
                 model = User
                 fields = ['account', 'status']
                 order_by = True
 
-        f = F({'o': 'username'}, queryset=self.qs)
+        f = F({'o': 'account'}, queryset=self.qs)
         self.assertQuerysetEqual(
             f.qs, ['aaron', 'alex', 'carl', 'jacob'], lambda o: o.username)
+
+    def test_reverted_ordering_uses_filter_name(self):
+        class F(FilterSet):
+            account = CharFilter(name='username')
+            class Meta:
+                model = User
+                fields = ['account', 'status']
+                order_by = True
+
+        f = F({'o': '-account'}, queryset=self.qs)
+        self.assertQuerysetEqual(
+            f.qs, ['jacob', 'carl', 'alex', 'aaron'], lambda o: o.username)
 
     def test_ordering_with_overridden_field_name(self):
         """

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -199,7 +199,7 @@ class FilterSetFormTests(TestCase):
         self.assertEqual(f.fields['o'].choices,
             [('username', 'Account'), ('-username', 'Account (descending)'), ('status', 'Status'), ('-status', 'Status (descending)')])
 
-    def test_ordering_uses_implicit_filter_name(self):
+    def test_ordering_uses_explicit_filter_name(self):
         class F(FilterSet):
             account = CharFilter(name='username')
 
@@ -210,7 +210,7 @@ class FilterSetFormTests(TestCase):
 
         f = F().form
         self.assertEqual(f.fields['o'].choices,
-            [('username', 'Account'), ('-username', 'Account (descending)'), ('status', 'Status'), ('-status', 'Status (descending)')])
+            [('account', 'Account'), ('-account', 'Account (descending)'), ('status', 'Status'), ('-status', 'Status (descending)')])
 
     def test_ordering_with_overridden_field_name(self):
         """
@@ -272,4 +272,3 @@ class FilterSetFormTests(TestCase):
         f = F().form
         self.assertEqual(
             f.fields['o'].choices, [('status', 'Current status')])
-


### PR DESCRIPTION
Precedence is given to the names declared as attributes on the FilterSet.

*Caution : this is an API change.*

If I define 

        class F(FilterSet):
            account = CharFilter(name='username')
            class Meta:
                model = User
                fields = ['account', 'status']
                order_by = True

# Before

* I filter like `account=isaac`
* I order like `o=username` or `o=-username`

# After 

* I filter like `account=isaac`
* I order like `o=account` or `o=-account`

# Why this change ?

I consider that if I define a custom filter name, it means that *my* API will never mention the name I "hide" (here, i hide `username`), so it's a matter of consistency.

From another point of view, when the field name spans one or several relationship levels, I might want to use a shorter name for ordering. From what I saw, there is no way to do that currently.

