### PR TITLE
Created Filter for NumericRange.

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -188,13 +188,14 @@ class NumericRangeFilter(Filter):
     def filter(self, qs, value):
         if value:
             if value.start and value.stop:
-                lookup = '%s__overlap' % self.name
-                return qs.filter(**{lookup: NumericRange(value.start, value.stop)})
+                lookup = '%s__%s' % (self.name, self.lookup_type)
+                return qs.filter(**{lookup: (value.start, value.stop)})
             else:
                 if value.start:
                     qs = qs.filter(**{'%s__startswith' % self.name: value.start})
                 if value.stop:
                     qs = qs.filter(**{'%s__endswith' % self.name: value.stop})
+        return qs
 
 
 class RangeFilter(Filter):

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -18,7 +18,7 @@ __all__ = [
     'Filter', 'CharFilter', 'BooleanFilter', 'ChoiceFilter',
     'TypedChoiceFilter', 'MultipleChoiceFilter', 'DateFilter',
     'DateTimeFilter', 'TimeFilter', 'ModelChoiceFilter',
-    'ModelMultipleChoiceFilter', 'NumberFilter', 'RangeFilter',
+    'ModelMultipleChoiceFilter', 'NumberFilter', 'NumericRangeFilter', 'RangeFilter',
     'DateRangeFilter', 'AllValuesFilter', 'MethodFilter'
 ]
 
@@ -180,6 +180,21 @@ class ModelMultipleChoiceFilter(MultipleChoiceFilter):
 
 class NumberFilter(Filter):
     field_class = forms.DecimalField
+
+
+class NumericRangeFilter(Filter):
+    field_class = RangeField
+
+    def filter(self, qs, value):
+        if value:
+            if value.start and value.stop:
+                lookup = '%s__overlap' % self.name
+                return qs.filter(**{lookup: NumericRange(value.start, value.stop)})
+            else:
+                if value.start:
+                    qs = qs.filter(**{'%s__startswith' % self.name: value.start})
+                if value.stop:
+                    qs = qs.filter(**{'%s__endswith' % self.name: value.stop})
 
 
 class RangeFilter(Filter):

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -116,6 +116,11 @@ for ``ManyToManyField`` by default.
 Filters based on a numerical value, used with ``IntegerField``, ``FloatField``,
 and ``DecimalField`` by default.
 
+``NumericRangeFilter``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Filters where a value is between two numerical values, or greater than a minimum or less than a maximum where only one limit value is provided. ::
+
 ``RangeFilter``
 ~~~~~~~~~~~~~~~
 

--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -119,7 +119,16 @@ and ``DecimalField`` by default.
 ``NumericRangeFilter``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Filters where a value is between two numerical values, or greater than a minimum or less than a maximum where only one limit value is provided. ::
+Filters where a value is between two numerical values, or greater than a minimum or less 
+than a maximum where only one limit value is provided. This filter is designed to work with 
+the Postgres Numerical Range Fields, including `IntegerRangeField`, `BigIntegerRangeField` and `FloatRangeField`, 
+available since Django 1.8. The default widget used is the `RangeField`.
+
+RangeField lookup_types can be used, including `overlap`, `contains`, and `contained_by`. More lookups can be 
+found in the Django docs ([https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/#querying-range-fields](https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/#querying-range-fields)).
+
+If the lower limit value is provided, the filter automatically defaults to `__startswith` as the lookup
+type and if only the upper limit value is provided, the filter uses `__endswith`.
 
 ``RangeFilter``
 ~~~~~~~~~~~~~~~

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -26,6 +26,7 @@ from django_filters.filters import TimeFilter
 from django_filters.filters import ModelChoiceFilter
 from django_filters.filters import ModelMultipleChoiceFilter
 from django_filters.filters import NumberFilter
+from django_filters.filters import NumericRangeFilter
 from django_filters.filters import RangeFilter
 from django_filters.filters import DateRangeFilter
 from django_filters.filters import AllValuesFilter
@@ -421,6 +422,41 @@ class NumberFilterTests(TestCase):
         qs.reset_mock()
         f.filter(qs, 0)
         qs.filter.assert_called_once_with(None__exact=0)
+
+class NumericRangeFilterTests(TestCase):
+
+    def test_default_field(self):
+        f = NumericRangeFilter()
+        field = f.field
+        self.assertIsInstance(field, RangeField)
+
+    def test_filtering(self):
+        qs = mock.Mock(spec=['filter'])
+        value = mock.Mock(start=20, stop=30)
+        f = NumericRangeFilter()
+        f.filter(qs, value)
+        qs.filter.assert_called_once_with(None__exact=(20, 30))
+
+    def test_filtering_skipped_with_none_value(self):
+        qs = mock.Mock(spec=['filter'])
+        f = NumericRangeFilter()
+        result = f.filter(qs, None)
+        self.assertEqual(qs, result)
+
+    def test_field_with_lookup_type(self):
+        qs = mock.Mock()
+        value = mock.Mock(start=20, stop=30)        
+        f = NumericRangeFilter(lookup_type=('overlap'))
+        f.filter(qs, value)
+        qs.filter.assert_called_once_with(None__overlap=(20, 30))  
+    
+    @unittest.expectedFailure
+    def test_filtering_lower_field_higher_than_upper_field(self):
+        qs = mock.Mock(spec=['filter'])
+        value = mock.Mock(start=35, stop=30)
+        f = NumericRangeFilter()
+        result = f.filter(qs, value)
+        self.assertEqual(qs, result)
 
 
 class RangeFilterTests(TestCase):


### PR DESCRIPTION
I recently upgraded to 1.8 and started making use of the [new range fields for Postgres](https://docs.djangoproject.com/en/1.8/ref/contrib/postgres/fields/). The existing Range Filter didn't work with it so I added a new one, which also possibly addresses the Numeric Range referenced here #75. 

Little typo in the second commit message. Meant to say NumericRange not IntegerRangeField