### PR TITLE
Support callables as limit_choices_to

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -176,6 +176,14 @@ class FilterSetMetaclass(type):
         return new_class
 
 
+def __queryset_of_relation_field(f):
+    limit_choices_filter = f.rel.limit_choices_to()\
+        if hasattr(f.rel.limit_choices_to, '__call__')\
+        else f.rel.limit_choices_to
+
+    return f.rel.to._default_manager.complex_filter(limit_choices_filter)
+
+
 FILTER_FOR_DBFIELD_DEFAULTS = {
     models.AutoField: {
         'filter_class': NumberFilter
@@ -201,24 +209,21 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
     models.OneToOneField: {
         'filter_class': ModelChoiceFilter,
         'extra': lambda f: {
-            'queryset': f.rel.to._default_manager.complex_filter(
-                f.rel.limit_choices_to),
+            'queryset': __queryset_of_relation_field(f),
             'to_field_name': f.rel.field_name,
         }
     },
     models.ForeignKey: {
         'filter_class': ModelChoiceFilter,
         'extra': lambda f: {
-            'queryset': f.rel.to._default_manager.complex_filter(
-                f.rel.limit_choices_to),
+            'queryset': __queryset_of_relation_field(f),
             'to_field_name': f.rel.field_name
         }
     },
     models.ManyToManyField: {
         'filter_class': ModelMultipleChoiceFilter,
         'extra': lambda f: {
-            'queryset': f.rel.to._default_manager.complex_filter(
-                f.rel.limit_choices_to),
+            'queryset': __queryset_of_relation_field(f),
         }
     },
     models.DecimalField: {

--- a/tests/models.py
+++ b/tests/models.py
@@ -54,6 +54,18 @@ class User(models.Model):
     def __str__(self):
         return self.username
 
+@python_2_unicode_compatible
+class UsersOfManager(models.Model):
+    users = models.ManyToManyField(User,
+                                   limit_choices_to={'is_active': True},
+                                   related_name='users_of_manager')
+    manager = models.ForeignKey(User,
+                                limit_choices_to=lambda: {'status': 1},
+                                related_name='his_users')
+
+    def __str__(self):
+        return self.manager.name + '_group'
+
 
 @python_2_unicode_compatible
 class AdminUser(User):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -8,7 +8,7 @@ from django_filters.filterset import FilterSet
 from django_filters.filters import CharFilter
 from django_filters.filters import ChoiceFilter
 
-from .models import User
+from .models import User, UsersOfManager
 from .models import Book
 from .models import STATUS_CHOICES
 
@@ -273,3 +273,19 @@ class FilterSetFormTests(TestCase):
         self.assertEqual(
             f.fields['o'].choices, [('status', 'Current status')])
 
+    def test_limit_choices_to(self):
+        User.objects.create(username='inactive', is_active=False, status=0)
+        User.objects.create(username='active', is_active=True, status=0)
+        User.objects.create(username='manager', is_active=False, status=1)
+
+        class F(FilterSet):
+            class Meta:
+                model = UsersOfManager
+                fields = ['users', 'manager']
+        f = F().form
+        self.assertEquals(
+            list(f.fields['users'].choices), [(2, u'active')]
+        )
+        self.assertEquals(
+            list(f.fields['manager'].choices), [(u'', u'---------'), (3, u'manager')]
+        )


### PR DESCRIPTION
According to https://docs.djangoproject.com/en/1.8/ref/models/fields/#django.db.models.ForeignKey.limit_choices_to
 it could be callable
```
 Either a dictionary, a Q object, or a callable returning a dictionary or Q object can be used.
```