### PR TITLE
Get rid of unnecessary code

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -28,7 +28,6 @@ class RangeField(forms.MultiValueField):
 class DateRangeField(RangeField):
 
     def __init__(self, *args, **kwargs):
-        super(DateRangeField, self).__init__(*args, **kwargs)
         fields = (
             forms.DateField(),
             forms.DateField())
@@ -48,7 +47,6 @@ class DateRangeField(RangeField):
 class TimeRangeField(RangeField):
 
     def __init__(self, *args, **kwargs):
-        super(TimeRangeField, self).__init__(*args, **kwargs)
         fields = (
             forms.TimeField(),
             forms.TimeField())


### PR DESCRIPTION
We don't need call super `__init__` twice. 
Thanks to @kkujawinski https://github.com/alex/django-filter/commit/978edc3795d02f92ff31a69c051bcc5bf142a99c#commitcomment-11257798