### PR TITLE
Update filters.txt

### DIFF
--- a/docs/ref/filters.txt
+++ b/docs/ref/filters.txt
@@ -242,9 +242,18 @@ queryset. This option can be used to eliminate duplicate results when using filt
 A boolean value that specifies whether the Filter should use ``filter`` or ``exclude`` on the queryset.
 Defaults to ``False``.
 
+ModelChoiceFilter and ModelMultipleChoiceFilter
+--------------
+
+
+``queryset``
+~~~~~~~~~~~
+
+``ModelChoiceFilter`` and ``ModelMultipleChoiceFilter`` require a queryset to operate on which must be passed as a kwarg.
+
 
 ``**kwargs``
 ~~~~~~~~~~~~
 
 Any extra keyword arguments will be provided to the accompanying form Field.
-This can be used to provide arguments like ``choices`` or ``queryset``.
+This can be used to provide arguments like ``choices``.


### PR DESCRIPTION
> While queryset is mentioned in the **kwargs section, it is in relation to "the accompanying form Field".  I was not using the forms for my project (REST API) so did not realise that a queryset kwarg was a hard requirement for ModelChoiceFilter and ModelMultipleChoiceFilter.

In relation to #146.  I haven't used whatever markdown the docs are in before so apologies if my formatting needs fixing.  Also it's a while since I had the issue and I don't really fully understand the package so probably good to double check if my changes are actually correct...