### PR TITLE
Minor correction to usage docs

### DIFF
--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -266,13 +266,13 @@ form class from which ``FilterSet.form`` will subclass.  This works similar to
 the ``form`` option on a ``ModelAdmin.``
 
 Group fields with ``together``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The inner ``Meta`` class also takes an optional ``together`` argument.  This 
 is a list of lists, each containing field names. For convenience can be a 
 single list/tuple when dealing with a single set of fields. Fields within a 
 field set must either be all or none present in the request for 
-``FilterSet.form`` to be valid.
+``FilterSet.form`` to be valid::
 
     import django_filters
 


### PR DESCRIPTION
The current docs don't properly style the one code excerpt, and 
have incorrect heading markdown.

I thought they were small enough to fit in one commit/pull.

[Doc section with incorrect styling](https://django-filter.readthedocs.org/en/latest/usage.html#group-fields-with-together)