### PR TITLE
Add filter to support 1,2,3 syntax

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 from django import forms
 
-from .widgets import RangeWidget, LookupTypeWidget
+from .widgets import CommaSeparatedValueWidget, RangeWidget, LookupTypeWidget
 
 
 class RangeField(forms.MultiValueField):
@@ -71,3 +71,12 @@ class LookupTypeField(forms.MultiValueField):
         if len(data_list)==2:
             return Lookup(value=data_list[0], lookup_type=data_list[1] or 'exact')
         return Lookup(value=None, lookup_type='exact')
+
+
+class CSVField(forms.CharField):
+    widget = CommaSeparatedValueWidget
+
+    def to_python(self, value):
+        if isinstance(value, list):
+            return value
+        return super(CSVField, self).to_python(value)

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -12,7 +12,9 @@ from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
 from .fields import (
-    RangeField, LookupTypeField, Lookup, DateRangeField, TimeRangeField)
+    CSVField, RangeField, LookupTypeField, Lookup, DateRangeField,
+    TimeRangeField)
+from .widgets import CommaSeparatedValueWidget
 
 
 __all__ = [
@@ -314,3 +316,7 @@ class MethodFilter(Filter):
         if parent_filter_method is not None:
             return parent_filter_method(qs, value)
         return qs
+
+
+class CSVFilter(Filter):
+    field_class = CSVField

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -320,3 +320,7 @@ class MethodFilter(Filter):
 
 class CSVFilter(Filter):
     field_class = CSVField
+
+    def __init__(self, lookup_type='in', *args, **kwargs):
+        super(CSVFilter, self).__init__(
+            lookup_type=lookup_type, *args, **kwargs)

--- a/docs/ref/widgets.txt
+++ b/docs/ref/widgets.txt
@@ -17,3 +17,11 @@ placeholders::
 2. ``query_string``: This is the query string for use in the ``href``
    option on the ``<a>`` elemeent.
 3. ``label``: This is the text to be displayed to the user.
+
+``CommaSeparatedValueWidget``
+~~~~~~~~~~~~~~
+
+This widget converts a comma-separated value for an <input>, into a list of
+values for an `__in` lookup. It has one method that you can overide for
+converting values from the inputted strings. ``customize()`` should return the
+value in the same type it's stored in the database.

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -3,7 +3,9 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from django.forms import TextInput, Select
+from django.utils.datastructures import MultiValueDict
 
+from django_filters.widgets import CommaSeparatedValueWidget
 from django_filters.widgets import RangeWidget
 from django_filters.widgets import LinkWidget
 from django_filters.widgets import LookupTypeWidget
@@ -135,3 +137,45 @@ class RangeWidgetTests(TestCase):
             -
             <input type="text" name="price_1" value="9.99" />""")
 
+
+class CommaSeparatedValueWidgetTests(TestCase):
+    def test_widget(self):
+        w = CommaSeparatedValueWidget()
+        self.assertHTMLEqual(w.render('price', ''), """
+            <input type="text" name="price" />""")
+
+        self.assertHTMLEqual(w.render('price', '1,2'), """
+            <input type="text" name="price" value="1,2" />""")
+
+        self.assertHTMLEqual(w.render('price', ['1', '2']), """
+            <input type="text" name="price" value="1,2" />""")
+
+    def test_widget_value_from_datadict(self):
+        w = CommaSeparatedValueWidget()
+        data = {'price': '1'}
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, ['1'])
+
+        data = {'price': '1,2'}
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, ['1', '2'])
+
+        data = MultiValueDict({'price': ['1']})
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, ['1'])
+
+        data = MultiValueDict({'price': ['1,2']})
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, ['1', '2'])
+
+        data = MultiValueDict({'price': ['1', '2']})
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, ['1', '2'])
+
+        data = {'price': None}
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, [])
+
+        data = {'price': ''}
+        result = w.value_from_datadict(data, {}, 'price')
+        self.assertEqual(result, [])


### PR DESCRIPTION
Based on discussion from https://github.com/alex/django-filter/issues/137

Using some of @kmwenja's work from [his comment](https://github.com/alex/django-filter/issues/137#issuecomment-77697870), and some from the original gist I had.

I considered using similar terms to Django for cleaning/validating the values, but I left it with the function names used in the comment where the cleaning was suggested.