### PR TITLE
Boolean widget

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -94,18 +94,8 @@ class BooleanFilter(Filter):
 
     def filter(self, qs, value):
         if value is not None:
-            value = self._convert_boolean(value)
             return qs.filter(**{self.name: value})
         return qs
-
-    def _convert_boolean(self, value):
-        """Convert JavaScript true/false values into the internal Python types.
-        """
-        if value == 'true':
-            value = True
-        elif value == 'false':
-            value = False
-        return value
 
 
 class ChoiceFilter(Filter):

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -94,8 +94,18 @@ class BooleanFilter(Filter):
 
     def filter(self, qs, value):
         if value is not None:
+            value = self._convert_boolean(value)
             return qs.filter(**{self.name: value})
         return qs
+
+    def _convert_boolean(self, value):
+        """Convert JavaScript true/false values into the internal Python types.
+        """
+        if value == 'true':
+            value = True
+        elif value == 'false':
+            value = False
+        return value
 
 
 class ChoiceFilter(Filter):

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -97,3 +97,23 @@ class LookupTypeWidget(forms.MultiWidget):
         if value is None:
             return [None, None]
         return value
+
+
+class BooleanWidget(forms.Widget):
+    """Convert true/false values into the internal Python True/False.
+    This can be used for AJAX queries that pass true/false from JavaScript's
+    internal types through.
+    """
+    def value_from_datadict(self, data, files, name):
+        """
+        """
+        value = super(BooleanWidget, self).value_from_datadict(
+            data, files, name)
+
+        if value is not None:
+            if value.lower() == 'true':
+                value = True
+            elif value.lower() == 'false':
+                value = False
+
+        return value

--- a/docs/ref/widgets.txt
+++ b/docs/ref/widgets.txt
@@ -8,12 +8,21 @@ arguments.
 ~~~~~~~~~~~~~~
 
 This widget renders each option as a link, instead of an actual <input>.  It has
-one method that you can overide for additional customizability.
+one method that you can override for additional customizability.
 ``option_string()`` should return a string with 3 Python keyword argument
 placeholders::
 
 1. ``attrs``: This is a string with all the attributes that will be on the
    final ``<a>`` tag.
 2. ``query_string``: This is the query string for use in the ``href``
-   option on the ``<a>`` elemeent.
+   option on the ``<a>`` element.
 3. ``label``: This is the text to be displayed to the user.
+
+``BooleanWidget``
+~~~~~~~~~~~~~~~~~
+
+This widget converts its input into Python's True/False values. It will convert
+all case variations of ``True`` and ``False`` into the internal Python values.
+To use it, pass this into the ``widgets`` argument of the ``BooleanFilter``::
+
+  active = BooleanFilter(widget=BooleanWidget())

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.test import TestCase
 from django.forms import TextInput, Select
 
+from django_filters.widgets import BooleanWidget
 from django_filters.widgets import RangeWidget
 from django_filters.widgets import LinkWidget
 from django_filters.widgets import LookupTypeWidget
@@ -135,3 +136,22 @@ class RangeWidgetTests(TestCase):
             -
             <input type="text" name="price_1" value="9.99" />""")
 
+
+class BooleanWidgetTests(TestCase):
+    """
+    """
+    def test_widget_value_from_datadict(self):
+        """
+        """
+        w = BooleanWidget()
+
+        trueActive = {'active': 'true'}
+        result = w.value_from_datadict(trueActive, {}, 'active')
+        self.assertEqual(result, True)
+
+        falseActive = {'active': 'false'}
+        result = w.value_from_datadict(falseActive, {}, 'active')
+        self.assertEqual(result, False)
+
+        result = w.value_from_datadict({}, {}, 'active')
+        self.assertEqual(result, None)


### PR DESCRIPTION
Implemented a boolean widget with test and documentation for #268 

This can be used for AJAX filters where the developer passes:

```js
query: {
  myvalue: true,
  anothervalue: false
}
```

This filter can recognise these variations and convert them into Python's internal True/False values.