### PR TITLE
Make `distinct()` call before replacing original `qs` reference (#283).

### DIFF
--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -84,9 +84,9 @@ class Filter(object):
             lookup = self.lookup_type
         if value in ([], (), {}, None, ''):
             return qs
-        qs = self.get_method(qs)(**{'%s__%s' % (self.name, lookup): value})
         if self.distinct:
             qs = qs.distinct()
+        qs = self.get_method(qs)(**{'%s__%s' % (self.name, lookup): value})
         return qs
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -189,7 +189,7 @@ class FilterTests(TestCase):
         qs = mock.Mock(spec=['filter', 'distinct'])
         f = Filter(name='somefield', distinct=True)
         f.filter(qs, 'value')
-        result = qs.distinct.assert_called_once()
+        result = qs.distinct.assert_called_once_with()
         self.assertNotEqual(qs, result)
 
 


### PR DESCRIPTION
By overwriting the reference to the original qs/mock it gets hard to assert that
`distinct()` was called in the tests. By calling `distinct()` before replacing
the reference to the original qs/mock the tests can stay the same.

Fixes #283 