### PR TITLE
Add timezone-aware enforcement

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from datetime import datetime, time
+from datetime import datetime, time, timedelta, tzinfo
 import decimal
 import sys
 
@@ -12,7 +12,7 @@ else:  # pragma: nocover
 
 import django
 from django import forms
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from django_filters.widgets import RangeWidget
 from django_filters.fields import (
@@ -120,13 +120,51 @@ class LookupTypeFieldTests(TestCase):
 
 
 class IsoDateTimeFieldTests(TestCase):
+    reference_str = "2015-07-19T13:34:51.759"
+    reference_dt = datetime(2015, 7, 19, 13, 34, 51, 759000)
 
     def test_datetime_string_is_parsed(self):
         f = IsoDateTimeField()
-        d = f.strptime("2015-07-19T13:34:51.759", IsoDateTimeField.ISO_8601)
+        d = f.strptime(self.reference_str + "", IsoDateTimeField.ISO_8601)
         self.assertTrue(isinstance(d, datetime))
 
     def test_datetime_string_with_timezone_is_parsed(self):
         f = IsoDateTimeField()
-        d = f.strptime("2015-07-19T13:34:51.759+01:00", IsoDateTimeField.ISO_8601)
+        d = f.strptime(self.reference_str + "+01:00", IsoDateTimeField.ISO_8601)
         self.assertTrue(isinstance(d, datetime))
+
+    def test_datetime_zulu(self):
+        f = IsoDateTimeField()
+        d = f.strptime(self.reference_str + "Z", IsoDateTimeField.ISO_8601)
+        self.assertTrue(isinstance(d, datetime))
+
+    def test_datetime_timezone_awareness(self):
+        # parsed datetimes should obey USE_TZ
+        f = IsoDateTimeField()
+        r = self.reference_dt.replace(tzinfo=f.default_timezone)
+
+        d = f.strptime(self.reference_str + "+01:00", IsoDateTimeField.ISO_8601)
+        self.assertTrue(isinstance(d.tzinfo, tzinfo))
+        self.assertEqual(d, r + r.utcoffset() - d.utcoffset())
+
+        d = f.strptime(self.reference_str + "", IsoDateTimeField.ISO_8601)
+        self.assertTrue(isinstance(d.tzinfo, tzinfo))
+        self.assertEqual(d, r)
+
+    @override_settings(USE_TZ=False)
+    def test_datetime_timezone_naivety(self):
+        # parsed datetimes should obey USE_TZ
+        f = IsoDateTimeField()
+        r = self.reference_dt.replace()
+
+        # It's necessary to override this here, since the field class is parsed
+        # when USE_TZ = True.
+        f.default_timezone = None
+
+        d = f.strptime(self.reference_str + "+01:00", IsoDateTimeField.ISO_8601)
+        self.assertTrue(d.tzinfo is None)
+        self.assertEqual(d, r - timedelta(hours=1))
+
+        d = f.strptime(self.reference_str + "", IsoDateTimeField.ISO_8601)
+        self.assertTrue(d.tzinfo is None)
+        self.assertEqual(d, r)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -12,7 +12,12 @@ else:  # pragma: nocover
 
 import django
 from django import forms
-from django.test import TestCase, override_settings
+from django.test import TestCase
+try:
+    from django.test import override_settings
+except ImportError:
+    # TODO: Remove this once Django 1.6 is EOL.
+    from django.test.utils import override_settings
 
 from django_filters.widgets import RangeWidget
 from django_filters.fields import (


### PR DESCRIPTION
Hi there - just a small PR for enforcing timezone awareness in `fields.IsoDateTimeField`.

**Problem:**
The underlying `django.utils.dateparse.parse_datetime` returns datetimes that *may* be timezone-aware, depending on whether the input string contains timezone information. When there is a mismatch with the `USE_TZ` setting, this can cause warnings/exceptions when querying the database. ie,
```
ValueError: SQLite backend does not support timezone-aware datetimes when USE_TZ is False.
```

**Probably correct behavior:**
Datetimes should be made tz-aware or tz-naive, depending on the `USE_TZ` setting. The logic of this was more or less ripped from DRF's `DateTimeField` input parsing, seen [here](https://github.com/tomchristie/django-rest-framework/blob/3.2.0/rest_framework/fields.py#L965-L969), which I would assume is the correct way to handle timezone conversion/awareness.