### PR TITLE
Add LOOKUPS.ALL shortcut, resolving #298

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -36,7 +36,7 @@ except ImportError:  # pragma: nocover
 
 from .filters import (Filter, CharFilter, BooleanFilter,
     ChoiceFilter, DateFilter, DateTimeFilter, TimeFilter, ModelChoiceFilter,
-    ModelMultipleChoiceFilter, NumberFilter)
+    ModelMultipleChoiceFilter, NumberFilter, LOOKUP_TYPES)
 
 
 ORDER_BY_FIELD = 'o'
@@ -58,6 +58,10 @@ class STRICTNESS(object):
     IGNORE = False
     RETURN_NO_RESULTS = True
     RAISE_VALIDATION_ERROR = "RAISE"
+
+
+class LOOKUPS(object):
+    ALL = '__all__'
 
 
 def get_declared_filters(bases, attrs, with_base_filters=True):
@@ -130,8 +134,13 @@ def filters_for_model(model, fields=None, exclude=None, filter_for_field=None,
                 field_dict[f] = filter_
         # If fields is a dictionary, it must contain lists.
         elif isinstance(fields, dict):
+            lookup_types = fields[f]
+
+            if lookup_types == LOOKUPS.ALL:
+                lookup_types = LOOKUP_TYPES
+
             # Create a filter for each lookup type.
-            for lookup_type in fields[f]:
+            for lookup_type in lookup_types:
                 filter_ = filter_for_field(field, f, lookup_type)
 
                 if filter_:

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -72,6 +72,17 @@ The above would generate 'price__lt', 'price__gt' and 'release_date' filters.
 The filter lookup type keyword 'exact' is the default and therefore never added
 to a filter name.
 
+To enable all filter lookups for a field, the ``LOOKUPS.ALL`` constant has been
+provided. This exposes filters for all django query terms.::
+
+    import django_filters
+    from django_filters.filterset import LOOKUPS
+
+    class ProductFilter(django_filters.FilterSet):
+        class Meta:
+            model = Product
+            fields = {'price': LOOKUPS.ALL, }
+
 Items in the ``fields`` sequence in the ``Meta`` class may include
 "relationship paths" using Django's ``__`` syntax to filter on fields on a
 related model::

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -14,6 +14,8 @@ from django.test import TestCase
 from django_filters.filterset import FilterSet
 from django_filters.filterset import FILTER_FOR_DBFIELD_DEFAULTS
 from django_filters.filterset import get_model_field
+from django_filters.filterset import LOOKUPS
+from django_filters.filterset import LOOKUP_TYPES
 from django_filters.filters import CharFilter
 from django_filters.filters import NumberFilter
 from django_filters.filters import ChoiceFilter
@@ -291,6 +293,22 @@ class FilterSetClassCreationTests(TestCase):
         self.assertEqual(len(F.base_filters), 3)
 
         expected_list = ['price', 'price__gte', 'price__lte', ]
+        self.assertTrue(checkItemsEqual(list(F.base_filters), expected_list))
+
+    def test_meta_fields_dictionary_all_lookups(self):
+        class F(FilterSet):
+
+            class Meta:
+                model = Book
+                fields = {'price': LOOKUPS.ALL, }
+
+        self.assertEqual(len(F.declared_filters), 0)
+        self.assertEqual(len(F.base_filters), len(LOOKUP_TYPES))
+
+        expected_list = ['price__%s' % l for l in LOOKUP_TYPES]
+        i = expected_list.index('price__exact')
+        expected_list[i] = 'price'
+
         self.assertTrue(checkItemsEqual(list(F.base_filters), expected_list))
 
     def test_meta_fields_containing_autofield(self):


### PR DESCRIPTION
Resolves #298.

One enhancement I can think of is to generate lookups only where applicable. For example, only generate the isnull filter when a field is nullable and only including the datetime relevant filters (day, hour, week_day, etc..) for datetime fields.