### PR TITLE
RangeWidget attributes

### DIFF
--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -80,7 +80,7 @@ class LinkWidget(forms.Widget):
 
 class RangeWidget(forms.MultiWidget):
     def __init__(self, attrs=None):
-        widgets = (forms.TextInput(attrs=attrs), forms.TextInput(attrs=attrs))
+        widgets = (forms.TextInput, forms.TextInput)
         super(RangeWidget, self).__init__(widgets, attrs)
 
     def decompress(self, value):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -136,6 +136,14 @@ class RangeWidgetTests(TestCase):
             -
             <input type="text" name="price_1" value="9.99" />""")
 
+    def test_widget_attributes(self):
+        w = RangeWidget(attrs={'type': 'date'})
+        self.assertEqual(len(w.widgets), 2)
+        self.assertHTMLEqual(w.render('date', ''), """
+            <input type="date" name="date_0" />
+            -
+            <input type="date" name="date_1" />""")
+
 
 class BooleanWidgetTests(TestCase):
     """


### PR DESCRIPTION
This PR allows to pass the same list of attributes to both `TextInput` widgets.

Fixes #306 