### PR TITLE
Make Django 1.8 the minimum supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,14 @@ language: python
 sudo: false
 
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 env:
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
   - DJANGO='django>=1.8.0,<1.9.0'
-  - DJANGO='django>=1.7.0,<1.8.0'
-  - DJANGO='django>=1.4.0,<1.5.0'
 
 install:
   - travis_retry pip install $DJANGO
@@ -28,20 +26,8 @@ notifications:
 matrix:
   exclude:
     - python: "3.2"
-      env: DJANGO='django>=1.4.0,<1.5.0'
-    - python: "3.2"
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
     - python: "3.3"
-      env: DJANGO='django>=1.4.0,<1.5.0'
-    - python: "3.3"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.4"
-      env: DJANGO='django>=1.4.0,<1.5.0'
-    - python: "2.6"
-      env: DJANGO='django>=1.7.0,<1.8.0'
-    - python: "2.6"
-      env: DJANGO='django>=1.8.0,<1.9.0'
-    - python: "2.6"
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
   allow_failures:
     - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Full documentation on `read the docs`_.
 Requirements
 ------------
 
-* Python 2.6+
-* Django 1.4.5+
+* Python 2.7+
+* Django 1.8.5+
 
 Installation
 ------------
@@ -50,7 +50,7 @@ And then in your view you could do::
 
 Django-filters additionally supports specifying FilterSet fields using a
 dictionary to specify filters with lookup types::
- 
+
     import django_filters
 
     class ProductFilter(django_filters.FilterSet):

--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -11,8 +11,6 @@ from django.utils import timezone
 
 from .widgets import RangeWidget, LookupTypeWidget
 
-from django.forms import UUIDField
-
 
 class RangeField(forms.MultiValueField):
     widget = RangeWidget

--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -9,22 +9,9 @@ from django.conf import settings
 from django.utils.dateparse import parse_datetime
 from django.utils import timezone
 
-# TODO: Remove this once Django 1.4 is EOL.
-try:
-    from django.utils.encoding import force_str
-except ImportError:
-    force_str = None
-
 from .widgets import RangeWidget, LookupTypeWidget
 
-try:
-    from django.forms import UUIDField
-except ImportError as e:
-    uuidfield_import_error = e
-    class UUIDField(object):
-        def __init__(self, *args, **kwargs):
-            # delay ImportError until it is used
-            raise uuidfield_import_error
+from django.forms import UUIDField
 
 
 class RangeField(forms.MultiValueField):
@@ -105,10 +92,6 @@ class IsoDateTimeField(forms.DateTimeField):
     default_timezone = timezone.get_default_timezone() if settings.USE_TZ else None
 
     def strptime(self, value, format):
-        # TODO: Remove this once Django 1.4 is EOL.
-        if force_str is not None:
-            value = force_str(value)
-
         if format == self.ISO_8601:
             parsed = parse_datetime(value)
             if parsed is None:  # Continue with other formats if doesn't match

--- a/django_filters/filters.py
+++ b/django_filters/filters.py
@@ -12,7 +12,7 @@ from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
 from .fields import (
-    RangeField, LookupTypeField, Lookup, DateRangeField, TimeRangeField, IsoDateTimeField, UUIDField)
+    RangeField, LookupTypeField, Lookup, DateRangeField, TimeRangeField, IsoDateTimeField)
 
 
 __all__ = [
@@ -107,7 +107,7 @@ class TypedChoiceFilter(Filter):
 
 
 class UUIDFilter(Filter):
-    field_class = UUIDField
+    field_class = forms.UUIDField
 
 
 class MultipleChoiceFilter(Filter):

--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -4,35 +4,19 @@ from __future__ import unicode_literals
 import types
 import copy
 import re
+from collections import OrderedDict
 
 from django import forms
 from django.forms.forms import NON_FIELD_ERRORS
 from django.core.validators import EMPTY_VALUES
 from django.db import models
+from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields import FieldDoesNotExist
+from django.db.models.fields.related import ForeignObjectRel
 from django.utils import six
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 from sys import version_info
-
-try:
-    from django.db.models.constants import LOOKUP_SEP
-except ImportError:  # pragma: nocover
-    # Django < 1.5 fallback
-    from django.db.models.sql.constants import LOOKUP_SEP  # noqa
-
-try:
-    from collections import OrderedDict
-except ImportError:  # pragma: nocover
-    # Django < 1.5 fallback
-    from django.utils.datastructures import SortedDict as OrderedDict  # noqa
-
-try:
-    from django.db.models.related import RelatedObject as ForeignObjectRel
-except ImportError:  # pragma: nocover
-    # Django >= 1.8 replaces RelatedObject with ForeignObjectRel
-    from django.db.models.fields.related import ForeignObjectRel
-
 
 from .filters import (Filter, CharFilter, BooleanFilter,
     ChoiceFilter, DateFilter, DateTimeFilter, TimeFilter, ModelChoiceFilter,

--- a/django_filters/widgets.py
+++ b/django_filters/widgets.py
@@ -10,10 +10,7 @@ except:
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms.widgets import flatatt
-try:
-    from django.utils.encoding import force_text
-except:  # pragma: nocover
-    from django.utils.encoding import force_unicode as force_text  # noqa
+from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,26 +3,17 @@ from __future__ import unicode_literals
 
 from datetime import datetime, time, timedelta, tzinfo
 import decimal
-import sys
-
-if sys.version_info >= (2, 7):
-    import unittest
-else:  # pragma: nocover
-    from django.utils import unittest  # noqa
+import unittest
 
 import django
 from django import forms
-from django.test import TestCase
-try:
-    from django.test import override_settings
-except ImportError:
-    # TODO: Remove this once Django 1.6 is EOL.
-    from django.test.utils import override_settings
+from django.test import TestCase, override_settings
 from django.utils.timezone import make_aware
 
 from django_filters.widgets import RangeWidget
 from django_filters.fields import (
     RangeField, LookupTypeField, Lookup, DateRangeField, TimeRangeField, IsoDateTimeField, UUIDField)
+
 
 def to_d(float_value):
     return decimal.Decimal('%.2f' % float_value)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -12,21 +12,11 @@ from django.utils.timezone import make_aware
 
 from django_filters.widgets import RangeWidget
 from django_filters.fields import (
-    RangeField, LookupTypeField, Lookup, DateRangeField, TimeRangeField, IsoDateTimeField, UUIDField)
+    RangeField, LookupTypeField, Lookup, DateRangeField, TimeRangeField, IsoDateTimeField)
 
 
 def to_d(float_value):
     return decimal.Decimal('%.2f' % float_value)
-
-
-class UUIDFieldTests(TestCase):
-
-    def test_field(self):
-        if django.VERSION < (1, 8):
-            with self.assertRaises(ImportError):
-                UUIDField()
-        else:
-            self.assertIs(UUIDField, forms.UUIDField)
 
 
 class RangeFieldTests(TestCase):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -3,12 +3,7 @@ from __future__ import unicode_literals
 
 import datetime
 import mock
-import sys
-
-if sys.version_info >= (2, 7):
-    import unittest
-else:  # pragma: nocover
-    from django.utils import unittest  # noqa
+import unittest
 
 from django.test import TestCase
 from django.utils import six
@@ -1331,4 +1326,3 @@ class MiscFilterSetTests(TestCase):
         f = F({'status': '2'}, queryset=qs)
         self.assertEqual(len(f.qs), 2)
         self.assertEqual(f.count(), 2)
-

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,16 +1,9 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from datetime import date, datetime, time
+from datetime import date, time, timedelta
 import mock
-import sys
-
-if sys.version_info >= (2, 7):
-    import unittest
-else:  # pragma: nocover
-    from django.utils import unittest  # noqa
-
-from datetime import timedelta
+import unittest
 
 import django
 from django import forms

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -15,8 +15,7 @@ from django_filters.fields import (
     RangeField,
     DateRangeField,
     TimeRangeField,
-    LookupTypeField,
-    UUIDField)
+    LookupTypeField)
 from django_filters.filters import (
     Filter,
     CharFilter,
@@ -203,7 +202,7 @@ class UUIDFilterTests(TestCase):
         if not django.VERSION < (1, 8):
             f = UUIDFilter()
             field = f.field
-            self.assertIsInstance(field, UUIDField)
+            self.assertIsInstance(field, forms.UUIDField)
         else:
             with self.assertRaises(ImportError):
                 UUIDFilter().field

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -1,12 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import mock
-import sys
-
-if sys.version_info >= (2, 7):
-    import unittest
-else:  # pragma: nocover
-    from django.utils import unittest  # noqa
+import unittest
 
 import django
 from django.db import models
@@ -45,6 +40,7 @@ def checkItemsEqual(L1, L2):
     TestCase.assertItemsEqual() is not available in Python 2.6.
     """
     return len(L1) == len(L2) and sorted(L1) == sorted(L2)
+
 
 class HelperMethodsTests(TestCase):
 


### PR DESCRIPTION
Now that Django 1.4 is EOL, it seems like a good time to update the minimum required version of Django.

- This cleans up a lot of the `# TODO: remove when Django 1.x is EOL` imports and code checks. 
- Drops python 2.6, adds python 3.5
- Drops Django < 1.8, which is the current LTS release.