### PR TITLE
Add support for GenericIPAddressField(A new field type since django1.7)

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -284,6 +284,9 @@ FILTER_FOR_DBFIELD_DEFAULTS = {
     models.IPAddressField: {
         'filter_class': CharFilter,
     },
+    models.GenericIPAddressField: {
+        'filter_class': CharFilter,
+    },
     models.CommaSeparatedIntegerField: {
         'filter_class': CharFilter,
     },

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -80,6 +80,7 @@ class DbFieldDefaultFiltersTests(TestCase):
             models.FloatField,
             models.IntegerField,
             models.IPAddressField,
+            models.GenericIPAddressField,
             models.NullBooleanField,
             models.PositiveIntegerField,
             models.PositiveSmallIntegerField,
@@ -103,7 +104,6 @@ class DbFieldDefaultFiltersTests(TestCase):
         to_check = [
             models.Field,
             models.BigIntegerField,
-            models.GenericIPAddressField,
             models.FileField,
             models.ImageField,
         ]


### PR DESCRIPTION
IPAddressField is deprecated in django1.7 in favor of GenericIPAddressField, so this is to add filter support for this new field.

There's another earlier pull request: #223 . 
However most of the time we just need to filter IP as a string, so a CharFilter is enough for now.

At the same time, we'd better keep IPAddressField and GenericIPAddressField using the same filter, so that users won't be confused.