### PR TITLE
Make Lookup object properly booled

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -58,7 +58,12 @@ class TimeRangeField(RangeField):
         super(TimeRangeField, self).__init__(fields, *args, **kwargs)
 
 
-Lookup = namedtuple('Lookup', ('value', 'lookup_type'))
+class Lookup(namedtuple('Lookup', ('value', 'lookup_type'))):
+    # python nature is test __len__ on tuple types for boolean check
+    def __len__(self):
+        if not self.value:
+            return 0
+        return 2
 
 
 class LookupTypeField(forms.MultiValueField):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -19,6 +19,20 @@ def to_d(float_value):
     return decimal.Decimal('%.2f' % float_value)
 
 
+class LookupBoolTests(TestCase):
+    def test_lookup_true(self):
+        self.assertTrue(Lookup(True, 'exact'))
+        self.assertTrue(Lookup(1, 'exact'))
+        self.assertTrue(Lookup('1', 'exact'))
+        self.assertTrue(Lookup(datetime.now(), 'exact'))
+
+    def test_lookup_false(self):
+        self.assertFalse(Lookup(False, 'exact'))
+        self.assertFalse(Lookup(0, 'exact'))
+        self.assertFalse(Lookup('', 'exact'))
+        self.assertFalse(Lookup(None, 'exact'))
+
+
 class RangeFieldTests(TestCase):
 
     def test_field(self):
@@ -46,7 +60,7 @@ class DateRangeFieldTests(TestCase):
 
         self.assertEqual(
             f.clean(['2015-01-01', '2015-01-10']),
-            slice(datetime(2015, 1, 1, 0, 0 , 0),
+            slice(datetime(2015, 1, 1, 0, 0, 0),
                   datetime(2015, 1, 10, 23, 59, 59, 999999)))
 
 


### PR DESCRIPTION
I have an issue. A lot of my custom filters was broken on last release. Case is that i override method filter of class Filter or another existing and test input value is `if value`, but today i get instance of Lookup class and it pass the test! Example:

    class SomeFilter(Filter):
        def filter(self, value, qs):
            if not value:
                return qs
            #  with instance of Lookup i always go there :(
            return qs.filter(someworkonvalue(value))


In pull request i define `__bool__` method on class Lookup, so my test passes correct now.


