### PR TITLE
Add link to alternative

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,3 +71,9 @@ If you have questions about usage or development you can join the
 
 .. _`read the docs`: https://django-filter.readthedocs.org/en/latest/
 .. _`mailing list`: http://groups.google.com/group/django-filter
+
+**********
+Alternatives
+**********
+If the project does not meet your requirements - change it by pull requests or use an alternate `django-filter
+<https://github.com/novapost/django-generic-filters>`_.


### PR DESCRIPTION


Hello,

I am would like suggest to add information about alex/django-filter to README.rst, so users who can't use django-generic-filters will use django-filter.

I do pull requests to django-generic-filters as novapost/django-generic-filters#42 for cross-linking.

Greetings,
