### PR TITLE
Explicitly stated minimum Django version for 0.12.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Version 0.12.0 (2016-01-07)
 ---------------------------
 
+* Raised minimum Django version to 1.8.x
+
 * FEATURE: Add support for custom ORM lookup types #221
 
 * FEATURE: Add JavaScript friendly BooleanWidget #270


### PR DESCRIPTION
As requested in https://github.com/alex/django-filter/issues/353#issuecomment-175499338