### PR TITLE
DateFromToRangeFilter now handle DateTimeFields

### DIFF
--- a/django_filters/fields.py
+++ b/django_filters/fields.py
@@ -34,8 +34,8 @@ class DateRangeField(RangeField):
 
     def __init__(self, *args, **kwargs):
         fields = (
-            forms.DateField(),
-            forms.DateField())
+            forms.DateTimeField(),
+            forms.DateTimeField())
         super(DateRangeField, self).__init__(fields, *args, **kwargs)
 
     def compress(self, data_list):


### PR DESCRIPTION
In docs, it says that DateFromToRangeFilter can be used with DateFieds and DateTimeFields but DateTimeFields doesn't work.

http://django-filter.readthedocs.org/en/latest/ref/filters.html#datefromtorangefilter