### PR TITLE
Update docs examples to use render instead of render_to_response

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ And then in your view you could do::
 
     def product_list(request):
         filter = ProductFilter(request.GET, queryset=Product.objects.all())
-        return render_to_response('my_app/template.html', {'filter': filter})
+        return render(request, 'my_app/template.html', {'filter': filter})
 
 Django-filters additionally supports specifying FilterSet fields using a
 dictionary to specify filters with lookup types::

--- a/docs/usage.txt
+++ b/docs/usage.txt
@@ -188,7 +188,7 @@ Now we need to write a view::
 
     def product_list(request):
         f = ProductFilter(request.GET, queryset=Product.objects.all())
-        return render_to_response('my_app/template.html', {'filter': f})
+        return render(request, 'my_app/template.html', {'filter': f})
 
 If a queryset argument isn't provided then all the items in the default manager
 of the model will be used.


### PR DESCRIPTION
Using `render_to_response` is discouraged in the [Django docs](https://docs.djangoproject.com/en/1.9/topics/http/shortcuts/#render-to-response). This patch changes the examples to use `render` instead.