### PR TITLE
Do not apply default order_by with raising strictness

### DIFF
--- a/django_filters/filterset.py
+++ b/django_filters/filterset.py
@@ -356,7 +356,9 @@ class BaseFilterSet(object):
                 except forms.ValidationError:
                     pass
 
-                if ordered_value in EMPTY_VALUES and self.strict:
+                # With a None-queryset, ordering must be enforced (#84).
+                if (ordered_value in EMPTY_VALUES and
+                        self.strict == STRICTNESS.RETURN_NO_RESULTS):
                     ordered_value = self.form.fields[self.order_by_field].choices[0][0]
 
                 if ordered_value:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -3,11 +3,13 @@ from __future__ import absolute_import, unicode_literals
 import mock
 import unittest
 
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.test import TestCase
 
 from django_filters.filterset import FilterSet
 from django_filters.filterset import FILTER_FOR_DBFIELD_DEFAULTS
+from django_filters.filterset import STRICTNESS
 from django_filters.filterset import get_model_field
 from django_filters.filters import CharFilter
 from django_filters.filters import NumberFilter
@@ -536,7 +538,21 @@ class FilterSetOrderingTests(TestCase):
 
     def test_ordering_on_unknown_value_results_in_default_ordering_without_strict(self):
         class F(FilterSet):
-            strict = False
+            strict = STRICTNESS.IGNORE
+
+            class Meta:
+                model = User
+                fields = ['username', 'status']
+                order_by = ['status']
+
+        self.assertFalse(F.strict)
+        f = F({'o': 'username'}, queryset=self.qs)
+        self.assertQuerysetEqual(
+            f.qs, ['alex', 'jacob', 'aaron', 'carl'], lambda o: o.username)
+
+    def test_ordering_on_unknown_value_results_in_default_ordering_with_strict_raise(self):
+        class F(FilterSet):
+            strict = STRICTNESS.RAISE_VALIDATION_ERROR
 
             class Meta:
                 model = User
@@ -544,6 +560,14 @@ class FilterSetOrderingTests(TestCase):
                 order_by = ['status']
 
         f = F({'o': 'username'}, queryset=self.qs)
+        with self.assertRaises(ValidationError) as excinfo:
+            f.qs.all()
+        self.assertEqual(excinfo.exception.message_dict,
+                         {'o': ['Select a valid choice. username is not one '
+                                'of the available choices.']})
+
+        # No default order_by should get applied.
+        f = F({}, queryset=self.qs)
         self.assertQuerysetEqual(
             f.qs, ['alex', 'jacob', 'aaron', 'carl'], lambda o: o.username)
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 import mock
 import unittest
 
-import django
 from django.db import models
 from django.test import TestCase
 


### PR DESCRIPTION
In https://github.com/alex/django-filter/blob/7dbd0c78c58386704fd7645c602f4417d1fdc0e8/django_filters/filterset.py#L359-L360:

    if ordered_value in EMPTY_VALUES and self.strict:
        ordered_value = self.form.fields[self.order_by_field].choices[0][0]

When skimming the issues about this, I came across #84, but it seems like it has been forgotten / is not needed anymore?!